### PR TITLE
forced hund_rudy_2004 not to use the analytic jacobian. 

### DIFF
--- a/src/fortests/SetupModel.cpp
+++ b/src/fortests/SetupModel.cpp
@@ -109,6 +109,8 @@ SetupModel::SetupModel(const double& rHertz,
                 break;
             case 4u:
                 mpModel.reset(new Cellhund_rudy_2004FromCellMLCvode(p_solver, p_stimulus));
+		// Hund Rudy doesn't play well with the use of an Analyic Jacobian, see Cooper, Spiteri, Mirams, 2015 paper
+		mpModel->ForceUseOfNumericalJacobian(true);
                 break;
             case 5u:
                 mpModel.reset(new Cellgrandi_pasqualini_bers_2010_ssFromCellMLCvode(p_solver, p_stimulus));


### PR DESCRIPTION
As discussed, this was causing problems with chatse codegen as it will happily generate a jacobian of sorts, even though it doesn't really work for As per Cooper-Spiteri-Mirams paper.