### PR TITLE
Switching to Model factory method

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ find_package(Chaste COMPONENTS heart)
 
 # Here we add extra arguments to force PyCML to use this extra argument (make Get and Set methods for
 # all metadata annotated variables). 
-set(Chaste_PYCML_EXTRA_ARGS "--expose-annotated-variables")
+set(Chaste_CODEGEN_EXTRA_ARGS "--use-model-factory")
 
 # ApPredict uses pthreads, so we specify that threads are required and add the necessary compile flag
 set(CMAKE_THREAD_PREFER_PTHREAD TRUE)

--- a/SConscript
+++ b/SConscript
@@ -47,7 +47,7 @@ chaste_libs_used = ['heart']
 
 # Change some flags just for this project
 env = SConsTools.CloneEnv(env)
-env['PYCML_EXTRA_ARGS'] = ['--expose-annotated-variables']
+env['Chaste_CODEGEN_EXTRA_ARGS'] = ['--use-model-factory']
 
 # Do the build magic
 result = SConsTools.DoProjectSConscript(project_name, chaste_libs_used, globals())

--- a/src/extra_models/README
+++ b/src/extra_models/README
@@ -3,4 +3,7 @@ Users can put additional cellml models in this directory.
 Once the project is built these will be available as pre-compiled models 
 and can be used with --model <name of cellml file (without.cellml)>.
 
-Please note: The additional cellml file cannot have the same name as one of the pre-included cellml files in src/cellml/cellml, as these would generated model code with conflicting names. In case you receive a compile error with regards to duplicate definitions, we suggest renaming the additional cellml files to avoid conflicts.
+Please note: The additional cellml file cannot have the same name as one of the pre-included cellml files in src/cellml/cellml
+as these would generated model code with conflicting names. 
+In case you receive a compile error with regards to duplicate definitions, 
+we suggest renaming the additional cellml files to avoid conflicts.

--- a/src/extra_models/README
+++ b/src/extra_models/README
@@ -1,4 +1,6 @@
 
-Users can put additional cellml models in this directory. Once the project is built these will be available as pre-compiled models and can be used with --model <name of cellml file (without.cellml)>.
+Users can put additional cellml models in this directory. 
+Once the project is built these will be available as pre-compiled models 
+and can be used with --model <name of cellml file (without.cellml)>.
 
 Please note: The additional cellml file cannot have the same name as one of the pre-included cellml files in src/cellml/cellml, as these would generated model code with conflicting names. In case you receive a compile error with regards to duplicate definitions, we suggest renaming the additional cellml files to avoid conflicts.

--- a/src/extra_models/README
+++ b/src/extra_models/README
@@ -1,0 +1,4 @@
+
+Users can put additional cellml models in this directory. Once the project is built these will be available as pre-compiled models and can be used with --model <name of cellml file (without.cellml)>.
+
+Please note: The additional cellml file cannot have the same name as one of the pre-included cellml files in src/cellml/cellml, as these would generated model code with conflicting names. In case you receive a compile error with regards to duplicate definitions, we suggest renaming the additional cellml files to avoid conflicts.

--- a/src/fortests/ModelFactory.cpp
+++ b/src/fortests/ModelFactory.cpp
@@ -1,26 +1,26 @@
 #include "ModelFactory.hpp"
 #include <iostream>
 
-std::unique_ptr<std::map<std::pair<std::string, std::string>, ModelFactory::TCreateMethod>> s_methods = std::make_unique<std::map<std::pair<std::string, std::string>, ModelFactory::TCreateMethod>>();
+std::unique_ptr<std::map<std::pair<std::string, std::string>, ModelFactory::TCreateMethod>> modelRegistry = std::make_unique<std::map<std::pair<std::string, std::string>, ModelFactory::TCreateMethod>>();
 
-void* ModelFactory::Create(const std::string& name, const std::string& type, boost::shared_ptr<AbstractIvpOdeSolver> p_solver, boost::shared_ptr<AbstractStimulusFunction> p_stimulus)
+void* ModelFactory::Create(const std::string& name, const std::string& type, boost::shared_ptr<AbstractIvpOdeSolver> pSolver, boost::shared_ptr<AbstractStimulusFunction> pStimulus)
 {
-    std::pair<std::string, std::string> nameType = std::make_pair(name, type);
-    auto it = s_methods->find(nameType);
-    if (it != s_methods->end())
+    std::pair<std::string, std::string> name_type = std::make_pair(name, type);
+    auto it = modelRegistry->find(name_type);
+    if (it != modelRegistry->end())
     {
-        return it->second(p_solver, p_stimulus); // call the createFunc
+        return it->second(pSolver, pStimulus); // call the createFunc
     }
 
     return nullptr;
 }
 
-bool ModelFactory::Register(const std::string name, const std::string& type, ModelFactory::TCreateMethod funcCreate)
+bool ModelFactory::Register(const std::string& name, const std::string& type, ModelFactory::TCreateMethod funcCreate)
 {
     std::pair<std::string, std::string> nameType = std::make_pair(name, type);
-    if (s_methods->count(nameType) == 0)
+    if (modelRegistry->count(nameType) == 0)
     {
-        s_methods->insert(std::pair<std::pair<std::string, std::string>, ModelFactory::TCreateMethod>(nameType, funcCreate));
+        modelRegistry->insert(std::pair<std::pair<std::string, std::string>, ModelFactory::TCreateMethod>(nameType, funcCreate));
         return true;
     }
     return false;

--- a/src/fortests/ModelFactory.cpp
+++ b/src/fortests/ModelFactory.cpp
@@ -1,0 +1,28 @@
+#include "ModelFactory.hpp"
+#include <iostream>
+
+std::unique_ptr<std::map<std::pair<std::string, std::string>, ModelFactory::TCreateMethod>> s_methods = std::make_unique<std::map<std::pair<std::string, std::string>, ModelFactory::TCreateMethod>>();
+
+void* ModelFactory::Create(const std::string& name, const std::string& type, boost::shared_ptr<AbstractIvpOdeSolver> p_solver, boost::shared_ptr<AbstractStimulusFunction> p_stimulus)
+{
+    std::pair<std::string, std::string> nameType = std::make_pair(name, type);
+    auto it = s_methods->find(nameType);
+    if (it != s_methods->end())
+    {
+        return it->second(p_solver, p_stimulus); // call the createFunc
+    }
+
+    return nullptr;
+}
+
+bool ModelFactory::Register(const std::string name, const std::string& type, ModelFactory::TCreateMethod funcCreate)
+{
+    std::pair<std::string, std::string> nameType = std::make_pair(name, type);
+    if (s_methods->count(nameType) == 0)
+    {
+        std::cout << name << " " << funcCreate << std::endl;
+        s_methods->insert(std::pair<std::pair<std::string, std::string>, ModelFactory::TCreateMethod>(nameType, funcCreate));
+        return true;
+    }
+    return false;
+}

--- a/src/fortests/ModelFactory.cpp
+++ b/src/fortests/ModelFactory.cpp
@@ -20,7 +20,6 @@ bool ModelFactory::Register(const std::string name, const std::string& type, Mod
     std::pair<std::string, std::string> nameType = std::make_pair(name, type);
     if (s_methods->count(nameType) == 0)
     {
-        std::cout << name << " " << funcCreate << std::endl;
         s_methods->insert(std::pair<std::pair<std::string, std::string>, ModelFactory::TCreateMethod>(nameType, funcCreate));
         return true;
     }

--- a/src/fortests/ModelFactory.cpp
+++ b/src/fortests/ModelFactory.cpp
@@ -1,5 +1,39 @@
+/*
+
+Copyright (c) 2005-2021, University of Oxford.
+All rights reserved.
+
+University of Oxford means the Chancellor, Masters and Scholars of the
+University of Oxford, having an administrative office at Wellington
+Square, Oxford OX1 2JD, UK.
+
+This file is part of Chaste.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ * Neither the name of the University of Oxford nor the names of its
+   contributors may be used to endorse or promote products derived from this
+   software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
 #include "ModelFactory.hpp"
-#include <iostream>
 
 std::unique_ptr<std::map<std::pair<std::string, std::string>, ModelFactory::TCreateMethod>> modelRegistry = std::make_unique<std::map<std::pair<std::string, std::string>, ModelFactory::TCreateMethod>>();
 
@@ -22,6 +56,8 @@ bool ModelFactory::Register(const std::string& name, const std::string& type, Mo
     {
         modelRegistry->insert(std::pair<std::pair<std::string, std::string>, ModelFactory::TCreateMethod>(nameType, funcCreate));
         return true;
+    }else{
+        EXCEPTION("Duplicate model: "+ name +" registration with the ModelFactory for type: "+ type +". If you are using your own version of this model please rename the cellml file.");
     }
     return false;
 }

--- a/src/fortests/ModelFactory.cpp
+++ b/src/fortests/ModelFactory.cpp
@@ -40,12 +40,18 @@ std::unique_ptr<std::map<std::pair<std::string, std::string>, ModelFactory::TCre
 
 bool ModelFactory::Exists(const std::string& name, const std::string& type)
 {
+    if(ModelFactory::modelRegistry == nullptr){
+        ModelFactory::modelRegistry = std::make_unique<std::map<std::pair<std::string, std::string>, ModelFactory::TCreateMethod>>();
+    }
     std::pair<std::string, std::string> name_type = std::make_pair(name, type);
     return ModelFactory::modelRegistry->find(name_type) != ModelFactory::modelRegistry->end();
 }
 
 void* ModelFactory::Create(const std::string& name, const std::string& type, boost::shared_ptr<AbstractIvpOdeSolver> pSolver, boost::shared_ptr<AbstractStimulusFunction> pStimulus)
 {
+    if(ModelFactory::modelRegistry == nullptr){
+        ModelFactory::modelRegistry = std::make_unique<std::map<std::pair<std::string, std::string>, ModelFactory::TCreateMethod>>();
+    }
     std::pair<std::string, std::string> name_type = std::make_pair(name, type);
     auto it = ModelFactory::modelRegistry->find(name_type);
     if (it != ModelFactory::modelRegistry->end())

--- a/src/fortests/ModelFactory.cpp
+++ b/src/fortests/ModelFactory.cpp
@@ -37,6 +37,12 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 std::unique_ptr<std::map<std::pair<std::string, std::string>, ModelFactory::TCreateMethod>> modelRegistry = std::make_unique<std::map<std::pair<std::string, std::string>, ModelFactory::TCreateMethod>>();
 
+bool ModelFactory::Exists(const std::string& name, const std::string& type)
+{
+    std::pair<std::string, std::string> name_type = std::make_pair(name, type);
+    return modelRegistry->find(name_type) != modelRegistry->end();
+}
+
 void* ModelFactory::Create(const std::string& name, const std::string& type, boost::shared_ptr<AbstractIvpOdeSolver> pSolver, boost::shared_ptr<AbstractStimulusFunction> pStimulus)
 {
     std::pair<std::string, std::string> name_type = std::make_pair(name, type);
@@ -45,8 +51,7 @@ void* ModelFactory::Create(const std::string& name, const std::string& type, boo
     {
         return it->second(pSolver, pStimulus); // call the createFunc
     }
-
-    return nullptr;
+    EXCEPTION("Model type combination does not exist cannot create: " + name + ", " + type);
 }
 
 bool ModelFactory::Register(const std::string& name, const std::string& type, ModelFactory::TCreateMethod funcCreate)

--- a/src/fortests/ModelFactory.cpp
+++ b/src/fortests/ModelFactory.cpp
@@ -35,38 +35,45 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "ModelFactory.hpp"
 
-ModelFactory::TModelMapping ModelFactory::modelRegistry;
+ModelFactory::TModelMapping ModelFactory::mpModelRegistry;
 
-ModelFactory::TModelMapping ModelFactory::getModelRegistry(){
-    if(ModelFactory::modelRegistry == nullptr){
-        ModelFactory::modelRegistry = std::make_unique<std::map<std::pair<std::string, std::string>, ModelFactory::TCreateMethod>>();
+ModelFactory::TModelMapping ModelFactory::getModelRegistry()
+{
+    if (ModelFactory::mpModelRegistry == nullptr)
+    {
+        ModelFactory::mpModelRegistry = std::make_unique<std::map<std::pair<std::string, std::string>, ModelFactory::TCreateMethod>>();
     }
-    return ModelFactory::modelRegistry;
+    return ModelFactory::mpModelRegistry;
 }
 
-bool ModelFactory::Exists(const std::string& name, const std::string& type)
+bool ModelFactory::Exists(const std::string& rName, const std::string& rType)
 {
-    std::pair<std::string, std::string> name_type = std::make_pair(name, type);
+    std::pair<std::string, std::string> name_type = std::make_pair(rName, rType);
     return ModelFactory::getModelRegistry()->find(name_type) != ModelFactory::getModelRegistry()->end();
 }
 
-void* ModelFactory::Create(const std::string& name, const std::string& type, boost::shared_ptr<AbstractIvpOdeSolver> pSolver, boost::shared_ptr<AbstractStimulusFunction> pStimulus)
+void* ModelFactory::Create(const std::string& rName, 
+                           const std::string& rType, 
+                           boost::shared_ptr<AbstractIvpOdeSolver> pSolver, 
+                           boost::shared_ptr<AbstractStimulusFunction> pStimulus)
 {
-    std::pair<std::string, std::string> name_type = std::make_pair(name, type);
+    std::pair<std::string, std::string> name_type = std::make_pair(rName, rType);
     auto it = ModelFactory::getModelRegistry()->find(name_type);
     if (it == ModelFactory::getModelRegistry()->end())
     {
-        EXCEPTION("Model type combination does not exist cannot create: " + name + ", " + type);
+        EXCEPTION("Model type combination does not exist cannot create: " + rName + ", " + rType);
     }
     return it->second(pSolver, pStimulus); // call the createFunc
 }
 
-bool ModelFactory::Register(const std::string& name, const std::string& type, ModelFactory::TCreateMethod funcCreate)
+bool ModelFactory::Register(const std::string& rName, 
+                            const std::string& rType, 
+                            ModelFactory::TCreateMethod funcCreate)
 {
-    std::pair<std::string, std::string> nameType = std::make_pair(name, type);
+    std::pair<std::string, std::string> nameType = std::make_pair(rName, rType);
     if (ModelFactory::getModelRegistry()->count(nameType) != 0)
     {
-        EXCEPTION("Duplicate model: "+ name +" registration with the ModelFactory for type: "+ type +". If you are using your own version of this model please rename the cellml file.");
+        EXCEPTION("Duplicate model: " + rName + " registration with the ModelFactory for type: " + rType + ". If you are using your own version of this model please rename the cellml file.");
     }
     ModelFactory::getModelRegistry()->insert(std::pair<std::pair<std::string, std::string>, ModelFactory::TCreateMethod>(nameType, funcCreate));
     return true;

--- a/src/fortests/ModelFactory.hpp
+++ b/src/fortests/ModelFactory.hpp
@@ -1,3 +1,38 @@
+/*
+
+Copyright (c) 2005-2021, University of Oxford.
+All rights reserved.
+
+University of Oxford means the Chancellor, Masters and Scholars of the
+University of Oxford, having an administrative office at Wellington
+Square, Oxford OX1 2JD, UK.
+
+This file is part of Chaste.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ * Neither the name of the University of Oxford nor the names of its
+   contributors may be used to endorse or promote products derived from this
+   software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
 #ifndef MODELFACTORY_HPP_
 #define MODELFACTORY_HPP_
 

--- a/src/fortests/ModelFactory.hpp
+++ b/src/fortests/ModelFactory.hpp
@@ -44,34 +44,45 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 /**
- * Class to provide a way to create models indirectly using the name of the cellml file and the model type.
- * This elliminated the need to hardcode which models are available.
- * Following the Factory design pattern, this class provides methods for generated cells to register their existance 
- * and methods for creating new instances of cells.
+ * Class to provide a way to create models indirectly using the name of the cellml 
+ * file and the model type. This eliminated the need to hardcode which models are available.
+ * Following the Factory design pattern, this class provides methods for generated 
+ * cells to register their existance and methods for creating new instances of cells.
  */
-class ModelFactory{
+class ModelFactory
+{
 public:
-
-    /** Type definition for methods to creat a new model*/
+    /** Type definition for methods to creat a new model */
     using TCreateMethod = void*(*)(boost::shared_ptr<AbstractIvpOdeSolver> p_solver, boost::shared_ptr<AbstractStimulusFunction> p_stimulus);
 
-    /** Type definition for Mapping of model name & type to create method*/
+    /** Type definition for Mapping of model name & type to create method */
     using TModelMapping = std::shared_ptr<std::map<std::pair<std::string, std::string>, TCreateMethod>>;
 
-    /** Method to check whether a given model, type combination has been registered and can be created */
-    static bool Exists(const std::string& name, const std::string& type);
+    /** Method to check whether a given model, type combination has been registered 
+     *  and can be created */
+    static bool Exists(const std::string& rName, const std::string& rType);
 
-    /** Method to create an given type instance of a model. The result needs to be type cast to the desired cell type (see TestModelFactory.hpp for examples)*/
-    static void* Create(const std::string& name, const std::string& type, boost::shared_ptr<AbstractIvpOdeSolver> pSolver, boost::shared_ptr<AbstractStimulusFunction> pStimulus);
+    /** Method to create an given type instance of a model. 
+     * The result needs to be type cast to the desired cell type 
+     * (see TestModelFactory.hpp for examples) */
+    static void* Create(const std::string& rName, 
+                        const std::string& rType, 
+                        boost::shared_ptr<AbstractIvpOdeSolver> pSolver, 
+                        boost::shared_ptr<AbstractStimulusFunction> pStimulus);
 
-    /** Registration method for generated cells to register themselves with the model factory*/
-    static bool Register(const std::string& name, const std::string& type, ModelFactory::TCreateMethod funcCreate);
+    /** Registration method for generated cells to register themselves with the model factory */
+    static bool Register(const std::string& rName, 
+                         const std::string& rType, 
+                         ModelFactory::TCreateMethod funcCreate);
 
 private:
-    /** Mapping of model name & type to create method */
-    static ModelFactory::TModelMapping modelRegistry;
+    // N.B. these need to be down here as the types are declared above.
 
-    /** Private getter, making sure the map isinitialised before using it*/
+    /** Mapping of model name & type to create method */
+    static ModelFactory::TModelMapping mpModelRegistry;
+
+    /** Private getter, making sure the map is initialised before using it */
     static TModelMapping  getModelRegistry();
 };
+
 #endif // MODELFACTORY_HPP_

--- a/src/fortests/ModelFactory.hpp
+++ b/src/fortests/ModelFactory.hpp
@@ -43,10 +43,22 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "RegularStimulus.hpp"
 
 
+/**
+ * Class to provide a way to create models indirectly using the name of the cellml file and the model type.
+ * This elliminated the need to hardcode which models are available.
+ * Following the Factory design pattern, this class provides methods for generated cells to register their existance 
+ * and methods for creating new instances of cells.
+ */
 class ModelFactory{
 public:
+
+    /** Map of model index to model name*/
     using TCreateMethod = void*(*)(boost::shared_ptr<AbstractIvpOdeSolver> p_solver, boost::shared_ptr<AbstractStimulusFunction> p_stimulus);
+
+    /** Method to create an given type instance of a model. The result needs to be type cast to the desired cell type (see TestModelFactory.hpp for examples)*/
     static void* Create(const std::string& name, const std::string& type, boost::shared_ptr<AbstractIvpOdeSolver> pSolver, boost::shared_ptr<AbstractStimulusFunction> pStimulus);
+
+    /** Registration method for generated cells to register themselves with the model factory*/
     static bool Register(const std::string& name, const std::string& type, ModelFactory::TCreateMethod funcCreate);
 };
 #endif // MODELFACTORY_HPP_

--- a/src/fortests/ModelFactory.hpp
+++ b/src/fortests/ModelFactory.hpp
@@ -46,7 +46,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 class ModelFactory{
 public:
     using TCreateMethod = void*(*)(boost::shared_ptr<AbstractIvpOdeSolver> p_solver, boost::shared_ptr<AbstractStimulusFunction> p_stimulus);
-    static void* Create(const std::string& name, const std::string& type, boost::shared_ptr<AbstractIvpOdeSolver> p_solver, boost::shared_ptr<AbstractStimulusFunction> p_stimulus);
-    static bool Register(const std::string name, const std::string& type, TCreateMethod funcCreate);
+    static void* Create(const std::string& name, const std::string& type, boost::shared_ptr<AbstractIvpOdeSolver> pSolver, boost::shared_ptr<AbstractStimulusFunction> pStimulus);
+    static bool Register(const std::string& name, const std::string& type, ModelFactory::TCreateMethod funcCreate);
 };
 #endif // MODELFACTORY_HPP_

--- a/src/fortests/ModelFactory.hpp
+++ b/src/fortests/ModelFactory.hpp
@@ -1,0 +1,17 @@
+#ifndef MODELFACTORY_HPP_
+#define MODELFACTORY_HPP_
+
+#include <memory>
+#include <string>
+#include <map>
+#include "AbstractIvpOdeSolver.hpp"
+#include "RegularStimulus.hpp"
+
+
+class ModelFactory{
+public:
+    using TCreateMethod = void*(*)(boost::shared_ptr<AbstractIvpOdeSolver> p_solver, boost::shared_ptr<AbstractStimulusFunction> p_stimulus);
+    static void* Create(const std::string& name, const std::string& type, boost::shared_ptr<AbstractIvpOdeSolver> p_solver, boost::shared_ptr<AbstractStimulusFunction> p_stimulus);
+    static bool Register(const std::string name, const std::string& type, TCreateMethod funcCreate);
+};
+#endif // MODELFACTORY_HPP_

--- a/src/fortests/ModelFactory.hpp
+++ b/src/fortests/ModelFactory.hpp
@@ -52,8 +52,10 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 class ModelFactory{
 public:
 
-    /** Map of model index to model name*/
+    /** Type definition for methods to creat a new model*/
     using TCreateMethod = void*(*)(boost::shared_ptr<AbstractIvpOdeSolver> p_solver, boost::shared_ptr<AbstractStimulusFunction> p_stimulus);
+
+    /** Type definition for Mapping of model name & type to create method*/
     using TModelMapping = std::shared_ptr<std::map<std::pair<std::string, std::string>, TCreateMethod>>;
 
     /** Method to check whether a given model, type combination has been registered and can be created */

--- a/src/fortests/ModelFactory.hpp
+++ b/src/fortests/ModelFactory.hpp
@@ -55,6 +55,9 @@ public:
     /** Map of model index to model name*/
     using TCreateMethod = void*(*)(boost::shared_ptr<AbstractIvpOdeSolver> p_solver, boost::shared_ptr<AbstractStimulusFunction> p_stimulus);
 
+    /** Method to check whether a given model, type combination has been registered and can be created */
+    static bool Exists(const std::string& name, const std::string& type);
+
     /** Method to create an given type instance of a model. The result needs to be type cast to the desired cell type (see TestModelFactory.hpp for examples)*/
     static void* Create(const std::string& name, const std::string& type, boost::shared_ptr<AbstractIvpOdeSolver> pSolver, boost::shared_ptr<AbstractStimulusFunction> pStimulus);
 

--- a/src/fortests/ModelFactory.hpp
+++ b/src/fortests/ModelFactory.hpp
@@ -63,5 +63,9 @@ public:
 
     /** Registration method for generated cells to register themselves with the model factory*/
     static bool Register(const std::string& name, const std::string& type, ModelFactory::TCreateMethod funcCreate);
+
+private:
+    /** Mapping of model name & type to create method */
+    static std::unique_ptr<std::map<std::pair<std::string, std::string>, TCreateMethod>> modelRegistry;
 };
 #endif // MODELFACTORY_HPP_

--- a/src/fortests/ModelFactory.hpp
+++ b/src/fortests/ModelFactory.hpp
@@ -54,6 +54,7 @@ public:
 
     /** Map of model index to model name*/
     using TCreateMethod = void*(*)(boost::shared_ptr<AbstractIvpOdeSolver> p_solver, boost::shared_ptr<AbstractStimulusFunction> p_stimulus);
+    using TModelMapping = std::shared_ptr<std::map<std::pair<std::string, std::string>, TCreateMethod>>;
 
     /** Method to check whether a given model, type combination has been registered and can be created */
     static bool Exists(const std::string& name, const std::string& type);
@@ -66,6 +67,9 @@ public:
 
 private:
     /** Mapping of model name & type to create method */
-    static std::unique_ptr<std::map<std::pair<std::string, std::string>, TCreateMethod>> modelRegistry;
+    static ModelFactory::TModelMapping modelRegistry;
+
+    /** Private getter, making sure the map isinitialised before using it*/
+    static TModelMapping  getModelRegistry();
 };
 #endif // MODELFACTORY_HPP_

--- a/src/fortests/SetupModel.cpp
+++ b/src/fortests/SetupModel.cpp
@@ -107,13 +107,13 @@ SetupModel::SetupModel(const double& rHertz,
         }
 
         // Create model using factory
-        AbstractCvodeCell* model = (AbstractCvodeCell*)ModelFactory::Create(modelName , "AnalyticCvode", p_solver, p_stimulus);
+        mpModel.reset((AbstractCvodeCell*)ModelFactory::Create(modelName , "AnalyticCvode", p_solver, p_stimulus));
 
-        if(model == nullptr){  // throw an error if the model isn't found
+        if(mpModel == nullptr){  // throw an error if the model isn't found
             EXCEPTION("No model matches this index: " + modelName);
         }
 
-        mpModel.reset(model);
+        //set numerical Jacobean if needed
         mpModel->ForceUseOfNumericalJacobian(SetupModel::forceNumericalJModels.find(modelName) != SetupModel::forceNumericalJModels.end());
     }
     //std::cout << "* model = " << mpModel->GetSystemName() << "\n";

--- a/src/fortests/SetupModel.cpp
+++ b/src/fortests/SetupModel.cpp
@@ -107,7 +107,7 @@ SetupModel::SetupModel(const double& rHertz,
         }
 
         // Create model using factory
-        AbstractCvodeCell* model = (AbstractCvodeCell*)ModelFactory::Create(modelName , "cvode", p_solver, p_stimulus);
+        AbstractCvodeCell* model = (AbstractCvodeCell*)ModelFactory::Create(modelName , "AnalyticCvode", p_solver, p_stimulus);
 
         if(model == nullptr){  // throw an error if the model isn't found
             EXCEPTION("No model matches this index: " + modelName);

--- a/src/fortests/SetupModel.cpp
+++ b/src/fortests/SetupModel.cpp
@@ -85,7 +85,7 @@ SetupModel::SetupModel(const double& rHertz,
     {
         modelName = std::to_string(modelIndex);
     }else if(CommandLineArguments::Instance()->OptionExists("--cellml")){// passed a file name via --cellml
-        WARNING("Argument --cellml <file> is depricated use --model <file> instead.");
+        WARNING("Argument --cellml <file> is deprecated use --model <file> instead.");
         modelName = CommandLineArguments::Instance()->GetStringCorrespondingToOption("--cellml");
     }else{ // passed a an index, model name or file name via --cellml
         modelName = CommandLineArguments::Instance()->GetStringCorrespondingToOption("--model");

--- a/src/fortests/SetupModel.cpp
+++ b/src/fortests/SetupModel.cpp
@@ -46,6 +46,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "FileFinder.hpp"
 #include "RegularStimulus.hpp"
 
+/* Mapping to implemnt backward compatibility with old hard coded model numbers */
 const std::map<std::string, std::string> SetupModel::modelMapping = {{"1", "shannon_wang_puglisi_weber_bers_2004"},
                                                                      {"2", "ten_tusscher_model_2006_epi"},
                                                                      {"3", "mahajan_shiferaw_2008"},

--- a/src/fortests/SetupModel.cpp
+++ b/src/fortests/SetupModel.cpp
@@ -93,7 +93,7 @@ SetupModel::SetupModel(const double& rHertz,
     }
     else
     {   
-        // passed a an index, model name or file name via --cellml
+        // passed a an index, model name or file name via --model
         modelName = CommandLineArguments::Instance()->GetStringCorrespondingToOption("--model");
     }
 

--- a/src/fortests/SetupModel.cpp
+++ b/src/fortests/SetupModel.cpp
@@ -38,6 +38,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "CheckpointArchiveTypes.hpp"
 
 #include "Exception.hpp"
+#include "Warnings.hpp"
 #include "SetupModel.hpp"
 
 #include "AbstractIvpOdeSolver.hpp"
@@ -68,39 +69,43 @@ SetupModel::SetupModel(const double& rHertz,
     boost::shared_ptr<AbstractStimulusFunction> p_stimulus;
     boost::shared_ptr<AbstractIvpOdeSolver> p_solver;
 
-    // If modelIndex is specified, then we have to use that, and ignore command line.
-    if (modelIndex == UNSIGNED_UNSET && CommandLineArguments::Instance()->OptionExists("--cellml"))
+    // Exceptions for wrong argument combinations
+    if (modelIndex == UNSIGNED_UNSET && !CommandLineArguments::Instance()->OptionExists("--cellml") && !CommandLineArguments::Instance()->OptionExists("--model"))
     {
-        // Try to use a dynamically loaded model
-        if (CommandLineArguments::Instance()->OptionExists("--model"))
-        {
-            EXCEPTION("You can only call ApPredict with the option '--model' OR '--cellml <file>'.");
-        }
-        std::string cellml_file_path = CommandLineArguments::Instance()->GetStringCorrespondingToOption("--cellml");
-        FileFinder cellml_file(cellml_file_path, RelativeTo::CWD);
-        std::vector<std::string> options = boost::assign::list_of("--expose-annotated-variables");
+        EXCEPTION("Argument \"--model <index>\" is required");
+    }
+    if (modelIndex == UNSIGNED_UNSET && CommandLineArguments::Instance()->OptionExists("--cellml") && CommandLineArguments::Instance()->OptionExists("--model"))
+    {
+        EXCEPTION("You can only call ApPredict with the option '--model' OR '--cellml <file>'.");
+    }
+
+    //Figure out which cellml we need name
+    std::string modelName;
+    if (modelIndex != UNSIGNED_UNSET) //passed a number
+    {
+        modelName = std::to_string(modelIndex);
+    }else if(CommandLineArguments::Instance()->OptionExists("--cellml")){// passed a file name via --cellml
+        WARNING("Argument --cellml <file> is depricated use --model <file> instead.");
+        modelName = CommandLineArguments::Instance()->GetStringCorrespondingToOption("--cellml");
+    }else{ // passed a an index, model name or file name via --cellml
+        modelName = CommandLineArguments::Instance()->GetStringCorrespondingToOption("--model");
+    }
+
+    // check if we have been given a file name and if so use that
+    FileFinder cellml_file(modelName, RelativeTo::CWD);
+    if (cellml_file.Exists()){
         if (mpHandler == NULL)
         {
             EXCEPTION("Trying to set up a dynamically loaded model without a working directory in SetupModel constructor.");
         }
-        CellMLLoader loader(cellml_file, *mpHandler, options);
+        CellMLLoader loader(cellml_file, *mpHandler, {});
         mpModel = loader.LoadCvodeCell();
-    }
-    else // Using a precompiled model
-    {
-        std::string modelName;
-        if (modelIndex == UNSIGNED_UNSET)
-        {
-            if (!CommandLineArguments::Instance()->OptionExists("--model"))
-            {
-                EXCEPTION("Argument \"--model <index>\" is required");
-            }
-            modelName = CommandLineArguments::Instance()->GetStringCorrespondingToOption("--model");
-        }else // If modelIndex is specified, then we have to use that, and ignore command line.
-        {
-            modelName = std::to_string(modelIndex);
-        }
 
+    }else{ // we have been given a model name or number
+        if(CommandLineArguments::Instance()->OptionExists("--cellml")){
+            EXCEPTION("Invalid file given with --cellml argument: " + modelName);
+        }
+        
         // Check if we have been given an index that can be mapped to a model name
         auto mapIterator = SetupModel::modelMapping.find(modelName);
         if(mapIterator != SetupModel::modelMapping.end()){
@@ -117,7 +122,6 @@ SetupModel::SetupModel(const double& rHertz,
         //set numerical Jacobean if needed
         mpModel->ForceUseOfNumericalJacobian(SetupModel::forceNumericalJModels.find(modelName) != SetupModel::forceNumericalJModels.end());
     }
-    //std::cout << "* model = " << mpModel->GetSystemName() << "\n";
 
     double s_magnitude = -15; // We will attempt to overwrite these with model specific ones below
     double s_duration = 3.0; // We will attempt to overwrite these with model specific ones below

--- a/src/fortests/SetupModel.cpp
+++ b/src/fortests/SetupModel.cpp
@@ -92,7 +92,7 @@ SetupModel::SetupModel(const double& rHertz,
     }
 
     // check if we have been given a file name and if so use that
-    FileFinder cellml_file(modelName, RelativeTo::CWD);
+    FileFinder cellml_file(modelName, RelativeTo::AbsoluteOrCwd);
     if (cellml_file.Exists()){
         if (mpHandler == NULL)
         {

--- a/src/fortests/SetupModel.cpp
+++ b/src/fortests/SetupModel.cpp
@@ -135,7 +135,7 @@ SetupModel::SetupModel(const double& rHertz,
         //set numerical Jacobean if needed
         mpModel->ForceUseOfNumericalJacobian(SetupModel::forceNumericalJModels.find(modelName) != SetupModel::forceNumericalJModels.end());
     }
-    std::cout << "* model = " << mpModel->GetSystemName() << std::endl;
+    //std::cout << "* model = " << mpModel->GetSystemName() << std::endl;
 
     double s_magnitude = -15; // We will attempt to overwrite these with model specific ones below
     double s_duration = 3.0; // We will attempt to overwrite these with model specific ones below

--- a/src/fortests/SetupModel.cpp
+++ b/src/fortests/SetupModel.cpp
@@ -113,9 +113,10 @@ SetupModel::SetupModel(const double& rHertz,
         }
 
         // Create model using factory
-        mpModel.reset((AbstractCvodeCell*)ModelFactory::Create(modelName , "AnalyticCvode", p_solver, p_stimulus));
+        if(ModelFactory::Exists(modelName , "AnalyticCvode")){
+            mpModel.reset((AbstractCvodeCell*)ModelFactory::Create(modelName , "AnalyticCvode", p_solver, p_stimulus));
 
-        if(mpModel == nullptr){  // throw an error if the model isn't found
+        }else{  // throw an error if the model isn't found
             EXCEPTION("No model matches this index: " + modelName);
         }
 

--- a/src/fortests/SetupModel.hpp
+++ b/src/fortests/SetupModel.hpp
@@ -41,6 +41,10 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "AbstractCvodeCell.hpp"
 #include "OutputFileHandler.hpp"
 
+#include "ModelFactory.hpp"
+#include <unordered_set>
+
+
 /**
  * Class to return a Cvode cell model with appropriate stimulus based on the
  * CellML default stimulus. This class reads the command line argument
@@ -50,6 +54,13 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 class SetupModel
 {
 private:
+
+    /** Map of model index to model name*/
+    static const std::map<std::string, std::string> modelMapping;
+
+    /** Set of names of models that require forced numerical Jacobian*/
+    static const std::unordered_set<std::string> forceNumericalJModels;
+
     /** Private default constructor to stop this being called and point in the direction of the other constructor */
     SetupModel(){};
 
@@ -91,6 +102,7 @@ public:
                "*   options: 1 = Shannon, 2 = TenTusscher (06), 3 = Mahajan,\n"
                "*            4 = Hund-Rudy, 5 = Grandi, 6 = O'Hara-Rudy 2011 (endo),\n"
                "*            7 = Paci (ventricular), 8 = O'Hara-Rudy CiPA v1 2017 (endo)\n"
+               "* OR --model <name of pre-compiled cellmlfile (without .cellml)>\n"
                "* OR --cellml <file>\n";
     }
 

--- a/src/fortests/SetupModel.hpp
+++ b/src/fortests/SetupModel.hpp
@@ -82,7 +82,9 @@ public:
      * If this is not present it uses sensible defaults.
      *
      * @param model_index  1 = Shannon, 2=TenTusscher, 3 = Mahajan, 4 = Hund-Rudy, 5 = Grandi,
-     *        6 = O'Hara-Rudy, 7 = Paci ventricular, 8 = CiPA O'Hara-Rudy v1.0, or use name of cellml (without.cellml)
+     *        6 = O'Hara-Rudy, 7 = Paci ventricular, 8 = CiPA O'Hara-Rudy v1.0
+     *        UNSIGNED_UNSET = look at the --model command line parameter: this can be a number, 
+     *        name of cellml file (without .) or path to cellml file.
      * @param hertz  The frequency of the regular stimulus that this model should use.
      * @param pHandler  An optional pointer to use as a working directory when
      *                  generating code on the fly from CellML (defaults to empty pointer).
@@ -103,7 +105,7 @@ public:
                "*            4 = Hund-Rudy, 5 = Grandi, 6 = O'Hara-Rudy 2011 (endo),\n"
                "*            7 = Paci (ventricular), 8 = O'Hara-Rudy CiPA v1 2017 (endo)\n"
                "* OR --model <name of pre-compiled cellmlfile (without .cellml)>\n"
-               "* OR --cellml <file>\n";
+               "* OR --model <file>\n";
     }
 
     /**

--- a/src/fortests/SetupModel.hpp
+++ b/src/fortests/SetupModel.hpp
@@ -105,7 +105,7 @@ public:
                "*            4 = Hund-Rudy, 5 = Grandi, 6 = O'Hara-Rudy 2011 (endo),\n"
                "*            7 = Paci (ventricular), 8 = O'Hara-Rudy CiPA v1 2017 (endo)\n"
                "* OR --model <name of pre-compiled cellmlfile (without .cellml)>\n"
-               "* OR --model <file>\n";
+               "* OR --model <file> (a CellML file, relative to current working directory or an absolute path)\n";
     }
 
     /**

--- a/src/fortests/SetupModel.hpp
+++ b/src/fortests/SetupModel.hpp
@@ -82,7 +82,7 @@ public:
      * If this is not present it uses sensible defaults.
      *
      * @param model_index  1 = Shannon, 2=TenTusscher, 3 = Mahajan, 4 = Hund-Rudy, 5 = Grandi,
-     *        6 = O'Hara-Rudy, 7 = Paci ventricular, 8 = CiPA O'Hara-Rudy v1.0
+     *        6 = O'Hara-Rudy, 7 = Paci ventricular, 8 = CiPA O'Hara-Rudy v1.0, or use name of cellml (without.cellml)
      * @param hertz  The frequency of the regular stimulus that this model should use.
      * @param pHandler  An optional pointer to use as a working directory when
      *                  generating code on the fly from CellML (defaults to empty pointer).

--- a/src/single_cell/ApPredictMethods.cpp
+++ b/src/single_cell/ApPredictMethods.cpp
@@ -928,6 +928,11 @@ void ApPredictMethods::Run()
 
 void ApPredictMethods::CommonRunMethod()
 {
+    if (!mSuppressOutput)
+    {
+        std::cout << "* model = " << mpModel->GetSystemName() << std::endl;
+    }
+
     // Arguments that take default values
     std::vector<std::vector<double>> IC50s;
     std::vector<std::vector<double>> hills;

--- a/test/ContinuousTestPack.txt
+++ b/test/ContinuousTestPack.txt
@@ -15,3 +15,4 @@ TestMetadataCellmlModels.hpp
 TestParameterBox.hpp
 TestPkpdReader.hpp
 TestTorsadePredict.hpp
+TestModelFactory.hpp

--- a/test/TestApPredict.hpp
+++ b/test/TestApPredict.hpp
@@ -106,14 +106,24 @@ public:
                                   "No model matches this index: bla");
         }
         {
-        CommandLineArgumentsMocker wrapper("--model 99999");
+            CommandLineArgumentsMocker wrapper("--model 99999");
 
-        TS_ASSERT_THROWS_THIS(SetupModel setup(1.0, UNSIGNED_UNSET),
-                              "No model matches this index: 99999");
+            TS_ASSERT_THROWS_THIS(SetupModel setup(1.0, UNSIGNED_UNSET),
+                                  "No model matches this index: 99999");
+        }
+        {
+            CommandLineArgumentsMocker wrapper("--cellml projects/ApPredict/src/cellml/cellml/ten_tusscher_model_2006_epi.cellml --plasma-concs 1 10 --pic50-herg 4.5 --plasma-conc-logscale false --output-dir ApPredict_output_long");
+
+            ApPredictMethods methods;
+            TS_ASSERT_EQUALS(Warnings::Instance()->GetNextWarningMessage(),"Argument --cellml <file> is depricated use --model <file> instead.");
+        }
+        {
+            CommandLineArgumentsMocker wrapper("--cellml bla.cellml");
+
+            TS_ASSERT_THROWS_THIS(SetupModel setup(1.0, UNSIGNED_UNSET),
+                                  "Invalid file given with --cellml argument: bla.cellml");
         }
 
-
-//WARNING("Argument --cellml <file> is depricated use --model <file> instead.");
     }
 
     void TestVoltageThresholdDetectionAlgorithm()

--- a/test/TestApPredict.hpp
+++ b/test/TestApPredict.hpp
@@ -115,7 +115,7 @@ public:
             CommandLineArgumentsMocker wrapper("--cellml projects/ApPredict/src/cellml/cellml/ten_tusscher_model_2006_epi.cellml --plasma-concs 1 10 --pic50-herg 4.5 --plasma-conc-logscale false --output-dir ApPredict_output_long");
 
             ApPredictMethods methods;
-            TS_ASSERT_EQUALS(Warnings::Instance()->GetNextWarningMessage(),"Argument --cellml <file> is depricated use --model <file> instead.");
+            TS_ASSERT_EQUALS(Warnings::Instance()->GetNextWarningMessage(),"Argument --cellml <file> is deprecated use --model <file> instead.");
         }
         {
             CommandLineArgumentsMocker wrapper("--cellml bla.cellml");

--- a/test/TestApPredict.hpp
+++ b/test/TestApPredict.hpp
@@ -85,6 +85,35 @@ public:
             TS_ASSERT_THROWS_THIS(ApPredictMethods methods,
                                   "The pacing frequency (0) set by '--pacing-freq' option must be a positive number.");
         }
+
+        {
+            CommandLineArgumentsMocker wrapper("--model 1 --cellml 1 --pacing-freq 1 --pacing-max-time 20 --plasma-concs 1 ");
+
+            TS_ASSERT_THROWS_THIS(SetupModel setup(1.0, UNSIGNED_UNSET),
+                                  "You can only call ApPredict with the option '--model' OR '--cellml <file>");
+        }
+
+        {
+            CommandLineArgumentsMocker wrapper("--cellml 1 --pacing-freq 1 --pacing-max-time 20 --plasma-concs 1 ");
+
+            TS_ASSERT_THROWS_THIS(SetupModel setup(1.0, UNSIGNED_UNSET),
+                                  "Invalid file given with --cellml argument: 1");
+        }
+        {
+            CommandLineArgumentsMocker wrapper("--model bla --pacing-freq 1 --pacing-max-time 20 --plasma-concs 1 ");
+
+            TS_ASSERT_THROWS_THIS(SetupModel setup(1.0, UNSIGNED_UNSET),
+                                  "No model matches this index: bla");
+        }
+        {
+        CommandLineArgumentsMocker wrapper("--model 99999");
+
+        TS_ASSERT_THROWS_THIS(SetupModel setup(1.0, UNSIGNED_UNSET),
+                              "No model matches this index: 99999");
+        }
+
+
+//WARNING("Argument --cellml <file> is depricated use --model <file> instead.");
     }
 
     void TestVoltageThresholdDetectionAlgorithm()

--- a/test/TestApPredict.hpp
+++ b/test/TestApPredict.hpp
@@ -143,7 +143,7 @@ public:
 
             TS_ASSERT_DELTA(threshold_voltage, thresholds_for_each_model[model_index - 1u], 1e-2);
         }
-    }
+   }
 
     /**
      * This test should emulate the standalone executable and read your command line arguments.

--- a/test/TestApPredict.hpp
+++ b/test/TestApPredict.hpp
@@ -90,7 +90,7 @@ public:
             CommandLineArgumentsMocker wrapper("--model 1 --cellml 1 --pacing-freq 1 --pacing-max-time 20 --plasma-concs 1 ");
 
             TS_ASSERT_THROWS_THIS(SetupModel setup(1.0, UNSIGNED_UNSET),
-                                  "You can only call ApPredict with the option '--model' OR '--cellml <file>");
+                                  "You can only call ApPredict with the option '--model' OR '--cellml <file>'.");
         }
 
         {

--- a/test/TestApPredictLong.hpp
+++ b/test/TestApPredictLong.hpp
@@ -72,6 +72,8 @@ public:
 
             ApPredictMethods methods;
             methods.Run();
+            TS_ASSERT_EQUALS(Warnings::Instance()->GetNumWarnings(), i == model_args.size()-1);
+
             std::vector<double> concs = methods.GetConcentrations();
 
             TS_ASSERT_EQUALS(concs.size(), 3u);

--- a/test/TestApPredictLong.hpp
+++ b/test/TestApPredictLong.hpp
@@ -62,9 +62,13 @@ public:
     {
         // Test a simple hERG block with TT06
         // loop over hardcoded and dynamically loaded.
+        // try both --model --cellml and --cellml and try both relative and absolute paths
+
+        FileFinder cellm_file("projects/ApPredict/src/cellml/cellml/ten_tusscher_model_2006_epi.cellml", RelativeTo::CWD);
         std::vector<std::string> model_args = { "--model 2",
                                                 "--model ten_tusscher_model_2006_epi",
                                                 "--model projects/ApPredict/src/cellml/cellml/ten_tusscher_model_2006_epi.cellml",
+                                                "--model " + cellm_file.GetAbsolutePath(),
                                                 "--cellml projects/ApPredict/src/cellml/cellml/ten_tusscher_model_2006_epi.cellml"};
         for (unsigned i = 0; i < model_args.size(); i++)
         {
@@ -72,7 +76,6 @@ public:
 
             ApPredictMethods methods;
             methods.Run();
-            TS_ASSERT_EQUALS(Warnings::Instance()->GetNumWarnings(), i == model_args.size()-1);
 
             std::vector<double> concs = methods.GetConcentrations();
 

--- a/test/TestApPredictLong.hpp
+++ b/test/TestApPredictLong.hpp
@@ -62,18 +62,13 @@ public:
     {
         // Test a simple hERG block with TT06
         // loop over hardcoded and dynamically loaded.
-        for (unsigned i = 0; i < 2; i++)
+        std::vector<std::string> model_args = { "--model 2",
+                                                "--model ten_tusscher_model_2006_epi",
+                                                "--model projects/ApPredict/src/cellml/cellml/ten_tusscher_model_2006_epi.cellml",
+                                                "--cellml projects/ApPredict/src/cellml/cellml/ten_tusscher_model_2006_epi.cellml"};
+        for (unsigned i = 0; i < model_args.size(); i++)
         {
-            std::string model_option;
-            if (i == 0)
-            {
-                model_option = "--model 2";
-            }
-            else
-            {
-                model_option = "--cellml projects/ApPredict/src/cellml/cellml/ten_tusscher_model_2006_epi.cellml";
-            }
-            CommandLineArgumentsMocker wrapper(model_option + " --plasma-concs 1 10 --pic50-herg 4.5 --plasma-conc-logscale false --output-dir ApPredict_output_long");
+            CommandLineArgumentsMocker wrapper(model_args[i] + " --plasma-concs 1 10 --pic50-herg 4.5 --plasma-conc-logscale false --output-dir ApPredict_output_long");
 
             ApPredictMethods methods;
             methods.Run();

--- a/test/TestModelFactory.hpp
+++ b/test/TestModelFactory.hpp
@@ -54,7 +54,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "ohara_rudy_cipa_v1_2017Cvode.hpp"
 
 #include "ohara_rudy_cipa_v1_2017.hpp"
-#include "ohara_rudy_cipa_v1_2017BackwardEuler.hpp"
+#include "ohara_rudy_cipa_v1_2017BackwardEulerOpt.hpp"
 
 class TestModelFactory : public CxxTest::TestSuite
 {
@@ -188,7 +188,7 @@ public:
         // Set up Normal, Cvode and BE models, compute 1 ms and compare
         Cellohara_rudy_cipa_v1_2017FromCellML normal(p_solver, p_stimulus);
         Cellohara_rudy_cipa_v1_2017FromCellMLCvode cvode(p_solver, p_stimulus);
-        Cellohara_rudy_cipa_v1_2017FromCellMLBackwardEuler be(p_solver, p_stimulus);
+        Cellohara_rudy_cipa_v1_2017FromCellMLBackwardEulerOpt be(p_solver, p_stimulus);
 
         // Create Normal, Cvode and BE models via factory
         boost::shared_ptr<AbstractCardiacCell> factoryNormal((AbstractCardiacCell*)ModelFactory::Create("ohara_rudy_cipa_v1_2017" , "Normal", p_solver, p_stimulus));

--- a/test/TestModelFactory.hpp
+++ b/test/TestModelFactory.hpp
@@ -65,7 +65,6 @@ class TestModelFactory : public CxxTest::TestSuite
 
     void checkModels(std::vector<boost::shared_ptr<AbstractCvodeCell>> models) {
 	for(unsigned int i=0; i < models.size(); i++){
-	    TS_ASSERT(models[i] != nullptr);
 	    TS_ASSERT(models[i]->GetNumberOfStateVariables() == referenceModels[i]->GetNumberOfStateVariables());
 	    TS_ASSERT(models[i]->GetVoltage() == referenceModels[i]->GetVoltage());
 	    TS_ASSERT(models[i]->GetNumberOfParameters() == referenceModels[i]->GetNumberOfParameters());
@@ -107,12 +106,17 @@ public:
 	boost::shared_ptr<AbstractStimulusFunction> p_stimulus;
 	boost::shared_ptr<AbstractIvpOdeSolver> p_solver;
 
-        std::unique_ptr<AbstractCvodeCell> model1((AbstractCvodeCell*)ModelFactory::Create("wrong_model_name" , "AnalyticCvode", p_solver, p_stimulus));
-        std::unique_ptr<AbstractCvodeCell> model2((AbstractCvodeCell*)ModelFactory::Create("shannon_wang_puglisi_weber_bers_2004" , "Wrong model type", p_solver, p_stimulus));
+        TS_ASSERT(ModelFactory::Exists("shannon_wang_puglisi_weber_bers_2004" , "AnalyticCvode"));
+        TS_ASSERT(! ModelFactory::Exists("wrong_model_name" , "AnalyticCvode"));
+        TS_ASSERT(! ModelFactory::Exists("shannon_wang_puglisi_weber_bers_2004" , "Wrong model type"));
 
-        TS_ASSERT(model1 == nullptr);
-        TS_ASSERT(model2 == nullptr);
-    }
+        std::unique_ptr<AbstractCvodeCell> model2((AbstractCvodeCell*)ModelFactory::Create("shannon_wang_puglisi_weber_bers_2004" , "AnalyticCvode", p_solver, p_stimulus));
+
+        TS_ASSERT_THROWS_THIS(ModelFactory::Create("wrong_model_name" , "AnalyticCvode", p_solver, p_stimulus),
+                              "Model type combination does not exist cannot create: wrong_model_name, AnalyticCvode");
+
+        TS_ASSERT_THROWS_THIS((AbstractCvodeCell*)ModelFactory::Create("shannon_wang_puglisi_weber_bers_2004" , "Wrong model type", p_solver, p_stimulus),
+                              "Model type combination does not exist cannot create: shannon_wang_puglisi_weber_bers_2004, Wrong model type");    }
 
     void TestModelFactorySetupModel()
     {

--- a/test/TestModelFactory.hpp
+++ b/test/TestModelFactory.hpp
@@ -174,12 +174,12 @@ public:
 
     void TestSetupModelCommandLineWrongIndex()
     {
-        CommandLineArgumentsMocker wrapper2("--model 99999");
-        TS_ASSERT_THROWS_THIS(SetupModel setup1(1.0, UNSIGNED_UNSET),
+        CommandLineArgumentsMocker wrapper("--model 99999");
+        TS_ASSERT_THROWS_THIS(SetupModel setup(1.0, UNSIGNED_UNSET),
                               "No model matches this index: 99999");
 
-        CommandLineArgumentsMocker wrapper("--model unknownmodel");
-        TS_ASSERT_THROWS_THIS(SetupModel setup1(1.0, UNSIGNED_UNSET),
+        CommandLineArgumentsMocker wrapper2("--model unknownmodel");
+        TS_ASSERT_THROWS_THIS(SetupModel setup2(1.0, UNSIGNED_UNSET),
                               "No model matches this index: unknownmodel");
     }
 

--- a/test/TestModelFactory.hpp
+++ b/test/TestModelFactory.hpp
@@ -1,0 +1,223 @@
+/*
+
+Copyright (c) 2005-2021, University of Oxford.
+All rights reserved.
+
+University of Oxford means the Chancellor, Masters and Scholars of the
+University of Oxford, having an administrative office at Wellington
+Square, Oxford OX1 2JD, UK.
+
+This file is part of Chaste.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ * Neither the name of the University of Oxford nor the names of its
+   contributors may be used to endorse or promote products derived from this
+   software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+#ifdef CHASTE_CVODE
+
+#ifndef _TESTMODELFACTORY_HPP_
+#define _TESTMODELFACTORY_HPP_
+
+#include "CommandLineArgumentsMocker.hpp"
+#include "EulerIvpOdeSolver.hpp"
+#include "SimpleStimulus.hpp"
+
+#include "ModelFactory.hpp"
+#include "SetupModel.hpp"
+
+#include "shannon_wang_puglisi_weber_bers_2004Cvode.hpp"
+#include "ten_tusscher_model_2006_epiCvode.hpp"
+#include "mahajan_shiferaw_2008Cvode.hpp"
+#include "hund_rudy_2004Cvode.hpp"
+#include "grandi_pasqualini_bers_2010_ssCvode.hpp"
+#include "ohara_rudy_2011_endoCvode.hpp"
+#include "paci_hyttinen_aaltosetala_severi_ventricularVersionCvode.hpp"
+#include "ohara_rudy_cipa_v1_2017Cvode.hpp"
+
+#include "ohara_rudy_cipa_v1_2017.hpp"
+#include "ohara_rudy_cipa_v1_2017BackwardEuler.hpp"
+
+class TestModelFactory : public CxxTest::TestSuite
+{
+    boost::shared_ptr<AbstractStimulusFunction> p_stimulus;
+    boost::shared_ptr<AbstractIvpOdeSolver> p_solver;
+    std::vector<std::unique_ptr<AbstractCvodeCell>> referenceModels;
+
+    void checkModels(std::vector<boost::shared_ptr<AbstractCvodeCell>> models) {
+	for(unsigned int i=0; i < models.size(); i++){
+	    TS_ASSERT(models[i] != nullptr);
+	    TS_ASSERT(models[i]->GetNumberOfStateVariables() == referenceModels[i]->GetNumberOfStateVariables());
+	    TS_ASSERT(models[i]->GetVoltage() == referenceModels[i]->GetVoltage());
+	    TS_ASSERT(models[i]->GetNumberOfParameters() == referenceModels[i]->GetNumberOfParameters());
+	}
+    }
+
+
+public:
+    void setUp() {
+	p_stimulus.reset(new SimpleStimulus(-25.5, 2.0, 50.0));
+	p_solver.reset(new EulerIvpOdeSolver);
+
+	referenceModels.push_back(std::make_unique<Cellshannon_wang_puglisi_weber_bers_2004FromCellMLCvode>(p_solver, p_stimulus));
+	referenceModels.push_back(std::make_unique<Cellten_tusscher_model_2006_epiFromCellMLCvode>(p_solver, p_stimulus));
+	referenceModels.push_back(std::make_unique<Cellmahajan_shiferaw_2008FromCellMLCvode>(p_solver, p_stimulus));
+	referenceModels.push_back(std::make_unique<Cellhund_rudy_2004FromCellMLCvode>(p_solver, p_stimulus));
+	referenceModels.push_back(std::make_unique<Cellgrandi_pasqualini_bers_2010_ssFromCellMLCvode>(p_solver, p_stimulus));
+	referenceModels.push_back(std::make_unique<Cellohara_rudy_2011_endoFromCellMLCvode>(p_solver, p_stimulus));
+	referenceModels.push_back(std::make_unique<Cellpaci_hyttinen_aaltosetala_severi_ventricularVersionFromCellMLCvode>(p_solver, p_stimulus));
+	referenceModels.push_back(std::make_unique<Cellohara_rudy_cipa_v1_2017FromCellMLCvode>(p_solver, p_stimulus));
+     }
+
+    void TestModelFactoryName()
+    {
+	boost::shared_ptr<AbstractCvodeCell> model1((AbstractCvodeCell*)ModelFactory::Create("shannon_wang_puglisi_weber_bers_2004" , "AnalyticCvode", p_solver, p_stimulus));
+        boost::shared_ptr<AbstractCvodeCell> model2((AbstractCvodeCell*)ModelFactory::Create("ten_tusscher_model_2006_epi" , "AnalyticCvode", p_solver, p_stimulus));
+        boost::shared_ptr<AbstractCvodeCell> model3((AbstractCvodeCell*)ModelFactory::Create("mahajan_shiferaw_2008" , "AnalyticCvode", p_solver, p_stimulus));
+        boost::shared_ptr<AbstractCvodeCell> model4((AbstractCvodeCell*)ModelFactory::Create("hund_rudy_2004" , "AnalyticCvode", p_solver, p_stimulus));
+        boost::shared_ptr<AbstractCvodeCell> model5((AbstractCvodeCell*)ModelFactory::Create("grandi_pasqualini_bers_2010_ss" , "AnalyticCvode", p_solver, p_stimulus));
+        boost::shared_ptr<AbstractCvodeCell> model6((AbstractCvodeCell*)ModelFactory::Create("ohara_rudy_2011_endo" , "AnalyticCvode", p_solver, p_stimulus));
+        boost::shared_ptr<AbstractCvodeCell> model7((AbstractCvodeCell*)ModelFactory::Create("paci_hyttinen_aaltosetala_severi_ventricularVersion" , "AnalyticCvode", p_solver, p_stimulus));
+        boost::shared_ptr<AbstractCvodeCell> model8((AbstractCvodeCell*)ModelFactory::Create("ohara_rudy_cipa_v1_2017" , "AnalyticCvode", p_solver, p_stimulus));
+
+        checkModels({model1, model2, model3, model4, model5, model6, model7, model8});
+    }
+
+    void TestWrongModelOrType()
+    {
+	boost::shared_ptr<AbstractStimulusFunction> p_stimulus;
+	boost::shared_ptr<AbstractIvpOdeSolver> p_solver;
+
+        std::unique_ptr<AbstractCvodeCell> model1((AbstractCvodeCell*)ModelFactory::Create("wrong_model_name" , "AnalyticCvode", p_solver, p_stimulus));
+        std::unique_ptr<AbstractCvodeCell> model2((AbstractCvodeCell*)ModelFactory::Create("shannon_wang_puglisi_weber_bers_2004" , "Wrong model type", p_solver, p_stimulus));
+
+        TS_ASSERT(model1 == nullptr);
+        TS_ASSERT(model2 == nullptr);
+    }
+
+    void TestModelFactorySetupModel()
+    {
+        SetupModel setup1(1.0, 1u);
+        SetupModel setup2(1.0, 2u);
+        SetupModel setup3(1.0, 3u);
+        SetupModel setup4(1.0, 4u);
+        SetupModel setup5(1.0, 5u);
+        SetupModel setup6(1.0, 6u);
+        SetupModel setup7(1.0, 7u);
+        SetupModel setup8(1.0, 8u);
+
+        checkModels({setup1.GetModel(), setup2.GetModel(), setup3.GetModel(), setup4.GetModel(), setup5.GetModel(), setup6.GetModel(), setup7.GetModel(), setup8.GetModel()});
+    }
+
+    void TestSetupModelCommandLineNumber()
+    {
+        CommandLineArgumentsMocker wrapper("--model 1");
+        SetupModel setup1(1.0, UNSIGNED_UNSET);
+        CommandLineArgumentsMocker wrapper2("--model 2");
+        SetupModel setup2(1.0, UNSIGNED_UNSET);
+        CommandLineArgumentsMocker wrapper3("--model 3");
+        SetupModel setup3(1.0, UNSIGNED_UNSET);
+        CommandLineArgumentsMocker wrapper4("--model 4");
+        SetupModel setup4(1.0, UNSIGNED_UNSET);
+        CommandLineArgumentsMocker wrapper5("--model 5");
+        SetupModel setup5(1.0, UNSIGNED_UNSET);
+        CommandLineArgumentsMocker wrapper6("--model 6");
+        SetupModel setup6(1.0, UNSIGNED_UNSET);
+        CommandLineArgumentsMocker wrapper7("--model 7");
+        SetupModel setup7(1.0, UNSIGNED_UNSET);
+        CommandLineArgumentsMocker wrapper8("--model 8");
+        SetupModel setup8(1.0, UNSIGNED_UNSET);
+
+        checkModels({setup1.GetModel(), setup2.GetModel(), setup3.GetModel(), setup4.GetModel(), setup5.GetModel(), setup6.GetModel(), setup7.GetModel(), setup8.GetModel()});
+    }
+
+    void TestSetupModelCommandLineName()
+    {
+        CommandLineArgumentsMocker wrapper("--model shannon_wang_puglisi_weber_bers_2004");
+        SetupModel setup1(1.0, UNSIGNED_UNSET);
+        CommandLineArgumentsMocker wrapper2("--model ten_tusscher_model_2006_epi");
+        SetupModel setup2(1.0, UNSIGNED_UNSET);
+        CommandLineArgumentsMocker wrapper3("--model mahajan_shiferaw_2008");
+        SetupModel setup3(1.0, UNSIGNED_UNSET);
+        CommandLineArgumentsMocker wrapper4("--model hund_rudy_2004");
+        SetupModel setup4(1.0, UNSIGNED_UNSET);
+        CommandLineArgumentsMocker wrapper5("--model grandi_pasqualini_bers_2010_ss");
+        SetupModel setup5(1.0, UNSIGNED_UNSET);
+        CommandLineArgumentsMocker wrapper6("--model ohara_rudy_2011_endo");
+        SetupModel setup6(1.0, UNSIGNED_UNSET);
+        CommandLineArgumentsMocker wrapper7("--model paci_hyttinen_aaltosetala_severi_ventricularVersion");
+        SetupModel setup7(1.0, UNSIGNED_UNSET);
+        CommandLineArgumentsMocker wrapper8("--model ohara_rudy_cipa_v1_2017");
+        SetupModel setup8(1.0, UNSIGNED_UNSET);
+
+        checkModels({setup1.GetModel(), setup2.GetModel(), setup3.GetModel(), setup4.GetModel(), setup5.GetModel(), setup6.GetModel(), setup7.GetModel(), setup8.GetModel()});
+    }
+
+    void TestSetupModelCommandLineWrongIndex()
+    {
+        CommandLineArgumentsMocker wrapper2("--model 99999");
+        TS_ASSERT_THROWS_THIS(SetupModel setup1(1.0, UNSIGNED_UNSET),
+                              "No model matches this index: 99999");
+
+        CommandLineArgumentsMocker wrapper("--model unknownmodel");
+        TS_ASSERT_THROWS_THIS(SetupModel setup1(1.0, UNSIGNED_UNSET),
+                              "No model matches this index: unknownmodel");
+    }
+
+    void TestOtherModelTypes()
+    {
+        // Check we are actually generating the correct type of the models
+        // Set up Normal, Cvode and BE models, compute 1 ms and compare
+        Cellohara_rudy_cipa_v1_2017FromCellML normal(p_solver, p_stimulus);
+        Cellohara_rudy_cipa_v1_2017FromCellMLCvode cvode(p_solver, p_stimulus);
+        Cellohara_rudy_cipa_v1_2017FromCellMLBackwardEuler be(p_solver, p_stimulus);
+
+        // Create Normal, Cvode and BE models via factory
+        boost::shared_ptr<AbstractCardiacCell> factoryNormal((AbstractCardiacCell*)ModelFactory::Create("ohara_rudy_cipa_v1_2017" , "Normal", p_solver, p_stimulus));
+        boost::shared_ptr<AbstractCvodeCell> factoryCvode((AbstractCvodeCell*)ModelFactory::Create("ohara_rudy_cipa_v1_2017" , "AnalyticCvode", p_solver, p_stimulus));
+        boost::shared_ptr<AbstractBackwardEulerCardiacCell<21>> factoryBe((AbstractBackwardEulerCardiacCell<21>*)ModelFactory::Create("ohara_rudy_cipa_v1_2017" , "BackwardEulerOpt", p_solver, p_stimulus));
+
+        // Compute 1 ms
+        normal.Compute(0.0, 1.0);
+        cvode.Compute(0.0, 1.0);
+        be.Compute(0.0, 1.0);
+        factoryNormal->Compute(0.0, 1.0);
+        factoryCvode->Compute(0.0, 1.0);
+        factoryBe->Compute(0.0, 1.0);
+
+        // The different model types and their Factory created version should have the same voltage
+        TS_ASSERT(normal.GetVoltage() == factoryNormal->GetVoltage());
+        TS_ASSERT(cvode.GetVoltage() == factoryCvode->GetVoltage());
+        TS_ASSERT(be.GetVoltage() == factoryBe->GetVoltage());
+
+        // The voltage for the different types should be very close but not identical
+        TS_ASSERT_DELTA(factoryNormal->GetVoltage(), factoryCvode->GetVoltage(), 1e-4);
+        TS_ASSERT_DELTA(factoryNormal->GetVoltage(), factoryBe->GetVoltage(), 1e-4);
+
+        TS_ASSERT(factoryCvode->GetVoltage() != factoryNormal->GetVoltage());
+        TS_ASSERT(factoryBe->GetVoltage() != factoryNormal->GetVoltage());
+        TS_ASSERT(factoryCvode->GetVoltage() != factoryBe->GetVoltage());
+    }
+
+};
+
+#endif //_TESTMODELFACTORY_HPP_
+#endif //_CHASTE_CVODE

--- a/test/TestModelFactory.hpp
+++ b/test/TestModelFactory.hpp
@@ -32,6 +32,7 @@ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
 OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 */
+
 #ifdef CHASTE_CVODE
 
 #ifndef _TESTMODELFACTORY_HPP_
@@ -181,6 +182,14 @@ public:
         TS_ASSERT_THROWS_THIS(SetupModel setup1(1.0, UNSIGNED_UNSET),
                               "No model matches this index: unknownmodel");
     }
+
+    void TestReRegisterExistingModel()
+    {
+        ModelFactory::Register("TestModel", "TestType", nullptr);
+        TS_ASSERT_THROWS_THIS(ModelFactory::Register("TestModel", "TestType", nullptr),
+                              "Duplicate model: TestModel registration with the ModelFactory for type: TestType. If you are using your own version of this model please rename the cellml file.");
+    }
+
 
     void TestOtherModelTypes()
     {


### PR DESCRIPTION
## Description
The PR switched over to using a factory method in which generated models register themselves and instances are indirectly created via the factory.

--cellml has become depricated (but still works)

The --model parameter can now be used as:
   --model <name of cellml file (without .cellml)> provided the cellml was pre-compiled
   --model <relative or absoulte path to cellml file>
  --model #number where 1 <= #number <=8 refering to previously hardcoded models

## Motivation and Context
This is in a move towards being able to add pre-compiled models without the need to change any code. A recompilation is still needed though.

## Testing
https://chaste.cs.ox.ac.uk/buildbot/builders/zProject%20ApPredict/builds/1282
