### PR TITLE
Adding ApPredict GitHub Actions workflow on self-hosted Ubuntu 20.04 runners

### DIFF
--- a/.github/workflows/ubuntu-2004.yml
+++ b/.github/workflows/ubuntu-2004.yml
@@ -22,6 +22,10 @@ jobs:
       CXX: g++
       
     steps:
+    - name: set number of processors
+      run: |
+        echo "NPROC: $(( $(nproc) < 12 ? $(nproc) : 12 ))" >> $GITHUB_ENV
+        
     - name: checkout Chaste repository
       uses: actions/checkout@v3
       with:
@@ -54,21 +58,21 @@ jobs:
         mkdir -p ${CHASTE_TEST_OUTPUT}
         
     - name: cmake configure
-      run: cmake -DCMAKE_BUILD_TYPE=Release ..
+      run: nice -n 10 cmake -DCMAKE_BUILD_TYPE=Release ..
       working-directory: Chaste/build
 
     - name: build core libraries
-      run: cmake --build . --parallel 8 --target chaste_core
+      run: nice -n 10 cmake --build . --parallel ${NPROC} --target chaste_core
       working-directory: Chaste/build
 
     - name: build heart
-      run: cmake --build . --parallel 8 --target chaste_heart
+      run: nice -n 10 cmake --build . --parallel ${NPROC} --target chaste_heart
       working-directory: Chaste/build
       
     - name: build ApPredict
-      run: cmake --build . --parallel 8 --target project_ApPredict
+      run: nice -n 10 cmake --build . --parallel ${NPROC} --target project_ApPredict
       working-directory: Chaste/build
 
     - name: run ApPredict test pack
-      run: ctest -j8 -L ApPredict --output-on-failure
+      run: nice -n 10 ctest -j${NPROC} -L ApPredict --output-on-failure
       working-directory: Chaste/build

--- a/.github/workflows/ubuntu-2004.yml
+++ b/.github/workflows/ubuntu-2004.yml
@@ -79,6 +79,10 @@ jobs:
       run: cmake --build . --parallel 8 --target chaste_lung
       working-directory: chaste-build-dir
 
+    - name: build Continuous test pack
+      run: cmake --build . --parallel 8 --target Continuous
+      working-directory: chaste-build-dir
+      
     - name: build ApPredict test pack
       run: cmake --build . --parallel 8 --target ApPredict
       working-directory: chaste-build-dir

--- a/.github/workflows/ubuntu-2004.yml
+++ b/.github/workflows/ubuntu-2004.yml
@@ -65,8 +65,8 @@ jobs:
       run: cmake --build . --parallel 8 --target chaste_heart
       working-directory: Chaste/build
       
-    - name: build ApPredict test pack
-      run: cmake --build . --parallel 8 --target ApPredict
+    - name: build ApPredict
+      run: cmake --build . --parallel 8 --target project_ApPredict
       working-directory: Chaste/build
 
     - name: run ApPredict test pack

--- a/.github/workflows/ubuntu-2004.yml
+++ b/.github/workflows/ubuntu-2004.yml
@@ -15,7 +15,7 @@ jobs:
   build-and-test:
 
     name: Build and Test on Ubuntu 20.04
-    runs-on: self-hosted ubuntu-20.04
+    runs-on: [self-hosted, ubuntu-20.04]
     env:
       CHASTE_TEST_OUTPUT: ${{ github.workspace }}/chaste-test-dir
 

--- a/.github/workflows/ubuntu-2004.yml
+++ b/.github/workflows/ubuntu-2004.yml
@@ -1,0 +1,88 @@
+name: Ubuntu 20.04 ApPredict test suite
+
+on:
+  push:
+    branches:
+      - develop
+      
+  schedule:
+    - cron:  '0 0 * * *'
+    
+  workflow_dispatch:
+  
+jobs:
+
+  build-and-test:
+
+    name: Build and Test on Ubuntu 20.04
+    runs-on: self-hosted ubuntu-20.04
+    env:
+      CHASTE_TEST_OUTPUT: ${{ github.workspace }}/chaste-test-dir
+
+    steps:
+    - name: checkout Chaste repository
+      uses: actions/checkout@v3
+      with:
+        repository: Chaste/Chaste
+      
+    - name: checkout ApPredict project
+      uses: actions/checkout@v3
+      with:
+        repository: Chaste/ApPredict
+        path: projects/ApPredict
+
+    - name: install dependencies
+      run: |
+        echo 'deb http://www.cs.ox.ac.uk/chaste/ubuntu focal/' | sudo tee -a /etc/apt/sources.list.d/chaste.list
+        sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 422C4D99
+        sudo apt update
+        sudo apt install chaste-dependencies
+        
+    - name: g++ version
+      run: |
+        g++ --version
+        g++ --version > gcc.version
+        
+    - name: cache build directory
+      uses: actions/cache@v3
+      id: cache
+      with:
+        path: chaste-build-dir
+        key: ${{ runner.os }}-${{ hashFiles('docs/ReleaseNotes.html') }}-${{ hashFiles('gcc.version') }}
+
+    - name: make build and test directories
+      run: |
+        mkdir -p chaste-build-dir
+        mkdir -p ${CHASTE_TEST_OUTPUT}
+        
+    - name: cmake configure
+      run: cmake -DCMAKE_BUILD_TYPE=Release ..
+      working-directory: chaste-build-dir
+
+    - name: build core libraries
+      run: cmake --build . --parallel 8 --target chaste_core
+      working-directory: chaste-build-dir
+
+    - name: build cell_based
+      run: cmake --build . --parallel 8 --target chaste_cell_based
+      working-directory: chaste-build-dir
+
+    - name: build crypt
+      run: cmake --build . --parallel 8 --target chaste_crypt
+      working-directory: chaste-build-dir
+
+    - name: build heart
+      run: cmake --build . --parallel 8 --target chaste_heart
+      working-directory: chaste-build-dir
+
+    - name: build lung
+      run: cmake --build . --parallel 8 --target chaste_lung
+      working-directory: chaste-build-dir
+
+    - name: build ApPredict test pack
+      run: cmake --build . --parallel 8 --target ApPredict
+      working-directory: chaste-build-dir
+
+    - name: run ApPredict test pack
+      run: ctest -j8 -L ApPredict --output-on-failure
+      working-directory: chaste-build-dir

--- a/.github/workflows/ubuntu-2004.yml
+++ b/.github/workflows/ubuntu-2004.yml
@@ -24,12 +24,14 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: Chaste/Chaste
+        submodules: recursive
       
     - name: checkout ApPredict project
       uses: actions/checkout@v3
       with:
         repository: Chaste/ApPredict
         path: projects/ApPredict
+        submodules: recursive
 
     - name: install dependencies
       run: |
@@ -63,24 +65,8 @@ jobs:
       run: cmake --build . --parallel 8 --target chaste_core
       working-directory: chaste-build-dir
 
-    - name: build cell_based
-      run: cmake --build . --parallel 8 --target chaste_cell_based
-      working-directory: chaste-build-dir
-
-    - name: build crypt
-      run: cmake --build . --parallel 8 --target chaste_crypt
-      working-directory: chaste-build-dir
-
     - name: build heart
       run: cmake --build . --parallel 8 --target chaste_heart
-      working-directory: chaste-build-dir
-
-    - name: build lung
-      run: cmake --build . --parallel 8 --target chaste_lung
-      working-directory: chaste-build-dir
-
-    - name: build Continuous test pack
-      run: cmake --build . --parallel 8 --target Continuous
       working-directory: chaste-build-dir
       
     - name: build ApPredict test pack

--- a/.github/workflows/ubuntu-2004.yml
+++ b/.github/workflows/ubuntu-2004.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
     - name: set number of processors
       run: |
-        echo "NPROC: $(( $(nproc) < 12 ? $(nproc) : 12 ))" >> $GITHUB_ENV
+        echo "NPROC=$(( $(nproc) < 12 ? $(nproc) : 12 ))" >> $GITHUB_ENV
         
     - name: checkout Chaste repository
       uses: actions/checkout@v3

--- a/.github/workflows/ubuntu-2004.yml
+++ b/.github/workflows/ubuntu-2004.yml
@@ -18,8 +18,6 @@ jobs:
     runs-on: [self-hosted, ubuntu-20.04]
     env:
       CHASTE_TEST_OUTPUT: ${{ github.workspace }}/chaste-test-dir
-      CHASTE_SRC_DIR: ${{ github.workspace }}/Chaste
-      CHASTE_BUILD_DIR: ${CHASTE_SRC_DIR}/build
       CC: gcc
       CXX: g++
       
@@ -28,14 +26,14 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: Chaste/Chaste
-        path: ${CHASTE_SRC_DIR}
+        path: Chaste
         submodules: recursive
       
     - name: checkout ApPredict project
       uses: actions/checkout@v3
       with:
         repository: Chaste/ApPredict
-        path: ${CHASTE_SRC_DIR}/projects/ApPredict
+        path: Chaste/projects/ApPredict
         submodules: recursive
         
     - name: ${CXX} version
@@ -47,30 +45,30 @@ jobs:
       uses: actions/cache@v3
       id: cache
       with:
-        path: ${CHASTE_BUILD_DIR}
+        path: Chaste/build
         key: ${{ runner.os }}-${{ hashFiles('docs/ReleaseNotes.html') }}-${{ hashFiles('compiler.version') }}
 
     - name: make build and test directories
       run: |
-        mkdir -p ${CHASTE_BUILD_DIR}
+        mkdir -p Chaste/build
         mkdir -p ${CHASTE_TEST_OUTPUT}
         
     - name: cmake configure
-      run: cmake -DCMAKE_BUILD_TYPE=Release ${CHASTE_SRC_DIR}
-      working-directory: ${CHASTE_BUILD_DIR}
+      run: cmake -DCMAKE_BUILD_TYPE=Release ..
+      working-directory: Chaste/build
 
     - name: build core libraries
       run: cmake --build . --parallel 8 --target chaste_core
-      working-directory: ${CHASTE_BUILD_DIR}
+      working-directory: Chaste/build
 
     - name: build heart
       run: cmake --build . --parallel 8 --target chaste_heart
-      working-directory: ${CHASTE_BUILD_DIR}
+      working-directory: Chaste/build
       
     - name: build ApPredict test pack
       run: cmake --build . --parallel 8 --target ApPredict
-      working-directory: ${CHASTE_BUILD_DIR}
+      working-directory: Chaste/build
 
     - name: run ApPredict test pack
       run: ctest -j8 -L ApPredict --output-on-failure
-      working-directory: ${CHASTE_BUILD_DIR}
+      working-directory: Chaste/build

--- a/.github/workflows/ubuntu-2004.yml
+++ b/.github/workflows/ubuntu-2004.yml
@@ -3,7 +3,7 @@ name: Ubuntu 20.04 ApPredict test suite
 on:
   push:
     branches:
-      - develop
+      - master
       
   schedule:
     - cron:  '0 0 * * *'

--- a/.github/workflows/ubuntu-2004.yml
+++ b/.github/workflows/ubuntu-2004.yml
@@ -14,65 +14,63 @@ jobs:
 
   build-and-test:
 
-    name: Build and Test on Ubuntu 20.04
+    name: Build and test on Ubuntu 20.04
     runs-on: [self-hosted, ubuntu-20.04]
     env:
       CHASTE_TEST_OUTPUT: ${{ github.workspace }}/chaste-test-dir
-
+      CHASTE_SRC_DIR: ${{ github.workspace }}/Chaste
+      CHASTE_BUILD_DIR: ${CHASTE_SRC_DIR}/build
+      CC: gcc
+      CXX: g++
+      
     steps:
     - name: checkout Chaste repository
       uses: actions/checkout@v3
       with:
         repository: Chaste/Chaste
+        path: ${CHASTE_SRC_DIR}
         submodules: recursive
       
     - name: checkout ApPredict project
       uses: actions/checkout@v3
       with:
         repository: Chaste/ApPredict
-        path: projects/ApPredict
+        path: ${CHASTE_SRC_DIR}/projects/ApPredict
         submodules: recursive
-
-    - name: install dependencies
-      run: |
-        echo 'deb http://www.cs.ox.ac.uk/chaste/ubuntu focal/' | sudo tee -a /etc/apt/sources.list.d/chaste.list
-        sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 422C4D99
-        sudo apt update
-        sudo apt install chaste-dependencies
         
-    - name: g++ version
+    - name: ${CXX} version
       run: |
-        g++ --version
-        g++ --version > gcc.version
+        ${CXX} --version
+        ${CXX} --version > compiler.version
         
     - name: cache build directory
       uses: actions/cache@v3
       id: cache
       with:
-        path: chaste-build-dir
-        key: ${{ runner.os }}-${{ hashFiles('docs/ReleaseNotes.html') }}-${{ hashFiles('gcc.version') }}
+        path: ${CHASTE_BUILD_DIR}
+        key: ${{ runner.os }}-${{ hashFiles('docs/ReleaseNotes.html') }}-${{ hashFiles('compiler.version') }}
 
     - name: make build and test directories
       run: |
-        mkdir -p chaste-build-dir
+        mkdir -p ${CHASTE_BUILD_DIR}
         mkdir -p ${CHASTE_TEST_OUTPUT}
         
     - name: cmake configure
-      run: cmake -DCMAKE_BUILD_TYPE=Release ..
-      working-directory: chaste-build-dir
+      run: cmake -DCMAKE_BUILD_TYPE=Release ${CHASTE_SRC_DIR}
+      working-directory: ${CHASTE_BUILD_DIR}
 
     - name: build core libraries
       run: cmake --build . --parallel 8 --target chaste_core
-      working-directory: chaste-build-dir
+      working-directory: ${CHASTE_BUILD_DIR}
 
     - name: build heart
       run: cmake --build . --parallel 8 --target chaste_heart
-      working-directory: chaste-build-dir
+      working-directory: ${CHASTE_BUILD_DIR}
       
     - name: build ApPredict test pack
       run: cmake --build . --parallel 8 --target ApPredict
-      working-directory: chaste-build-dir
+      working-directory: ${CHASTE_BUILD_DIR}
 
     - name: run ApPredict test pack
       run: ctest -j8 -L ApPredict --output-on-failure
-      working-directory: chaste-build-dir
+      working-directory: ${CHASTE_BUILD_DIR}


### PR DESCRIPTION
### Description

- This PR adds a GitHub Actions workflow to build and run the ApPredict project test pack with a self-hosted runner on Ubuntu 20.04.
- The workflow, (1) is scheduled to run every midnight, (2) is triggered when a new commit is made to the ApPredict repository, and (3) can be triggered manually.

### Motivation and Context
- This PR is part of [Chaste ticket 3099](https://chaste.cs.ox.ac.uk/trac/ticket/3099) (Migrate CI from Buildbot to GitHub actions ).
- For existing GitHub Actions workflows on the Chaste repository, see [Chaste/Chaste/.github/workflows](https://github.com/Chaste/Chaste/tree/develop/.github/workflows/).

### Testing
- This GitHub Actions workflow has been [tested on a fork](https://github.com/kwabenantim/ApPredict/actions).

### Additional Notes
- A self-hosted runner should be added, preferably at the organization level so multiple repositories can share it: [Adding a self-hosted runner to an organization](https://docs.github.com/en/actions/hosting-your-own-runners/adding-self-hosted-runners#adding-a-self-hosted-runner-to-an-organization) (this will generate a token that is required for configuring the runner).
- This workflow assumes that self-hosted runners have  the required dependencies for building and testing Chaste pre-installed.
