### PR TITLE
Add chaste branch to github actions workflow

### DIFF
--- a/.github/workflows/ubuntu-2004.yml
+++ b/.github/workflows/ubuntu-2004.yml
@@ -8,7 +8,12 @@ on:
   schedule:
     - cron:  '0 0 * * *'
     
-  workflow_dispatch:
+  workflow_dispatch:  
+    inputs:
+      chaste_branch:
+        description: "Chaste branch"
+        default: "develop"
+        type: "string"
   
 jobs:
 
@@ -31,6 +36,7 @@ jobs:
       with:
         repository: Chaste/Chaste
         path: Chaste
+        branch: ${{ inputs.chaste_branch }}
         submodules: recursive
       
     - name: checkout ApPredict project


### PR DESCRIPTION
Add chaste branch to github actions workflow, so that the workflow can be (manually) triggered with a different Chaste branch if required.