### PR TITLE
preventing re-download of cellml files should fix double cmake bug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,8 @@
 # Note that the order in which components are specified does not matter.
 
 include(FetchContent)
-#message (STATUS "Downloading APPredict cellml files to ${CMAKE_CURRENT_SOURCE_DIR}/src/cellml")
+message (STATUS "Downloading APPredict cellml files to ${CMAKE_CURRENT_SOURCE_DIR}/src/cellml")
+Set(FETCHCONTENT_UPDATES_DISCONNECTED ON)
 FetchContent_Declare(CellML_repo_appredict
                      GIT_REPOSITORY https://github.com/Chaste/cellml.git
                      GIT_TAG c26e1a0939e8c619e2ba10fe41d1af495503f6a1


### PR DESCRIPTION
@mirams this should help with the bug you were seeing when doing cmake twice. It does mean that if you make any changes to the cellml file sin the repo between the 2 seperate cmake commands being run thye won't be picked up and that a clean build dir would be required to pick up cellml file changes.

It seems to work for me, but have a try and see if this indeed fixes it for your usecase.