### PR TITLE
Limit slack notifications to schedule trigger

### DIFF
--- a/.github/workflows/ubuntu-tests.yml
+++ b/.github/workflows/ubuntu-tests.yml
@@ -79,7 +79,7 @@ jobs:
         working-directory: build
 
       - name: Slack notification
-        if: failure()
+        if: ${{ failure() && github.event_name == 'schedule' }}
         uses: slackapi/slack-github-action@v2.0.0
         with:
           method: chat.postMessage


### PR DESCRIPTION
### Summary
Slack notifications only need to be sent for test failures triggered by the cron job `schedule` since those aren't closely monitored.

Sufficient notifications (via email, github landing page) are already sent for test failures triggered by PRs and other action triggers. Those also tend to be watched closely.

Limiting slack notifications to the `schedule` trigger will avoid token issues with PRs from forks.