### PR TITLE
Upgrade github actions

### DIFF
--- a/.github/workflows/ubuntu-tests.yml
+++ b/.github/workflows/ubuntu-tests.yml
@@ -33,13 +33,16 @@ jobs:
           repository: Chaste/Chaste
           path: Chaste
           ref: ${{ env.chaste_branch }}
-
+        
       - name: Checkout ApPredict
         uses: actions/checkout@v6
         with:
           repository: Chaste/ApPredict
           path: Chaste/projects/ApPredict
 
+      - name: Force fail
+        run: exit 1
+        
       - name: Setup directories
         run: |
           mkdir -p build
@@ -79,7 +82,7 @@ jobs:
         working-directory: build
 
       - name: Slack notification
-        if: ${{ failure() && github.event_name == 'schedule' }}
+        if: ${{ failure() }}
         uses: slackapi/slack-github-action@v3.0.1
         with:
           method: chat.postMessage

--- a/.github/workflows/ubuntu-tests.yml
+++ b/.github/workflows/ubuntu-tests.yml
@@ -28,14 +28,14 @@ jobs:
 
     steps:
       - name: Checkout Chaste/${{ env.chaste_branch }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: Chaste/Chaste
           path: Chaste
           ref: ${{ env.chaste_branch }}
 
       - name: Checkout ApPredict
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: Chaste/ApPredict
           path: Chaste/projects/ApPredict
@@ -80,7 +80,7 @@ jobs:
 
       - name: Slack notification
         if: ${{ failure() && github.event_name == 'schedule' }}
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@v3.0.1
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}

--- a/.github/workflows/ubuntu-tests.yml
+++ b/.github/workflows/ubuntu-tests.yml
@@ -39,9 +39,6 @@ jobs:
         with:
           repository: Chaste/ApPredict
           path: Chaste/projects/ApPredict
-
-      - name: Force fail
-        run: exit 1
         
       - name: Setup directories
         run: |
@@ -82,7 +79,7 @@ jobs:
         working-directory: build
 
       - name: Slack notification
-        if: ${{ failure() }}
+        if: ${{ failure() && github.event_name == 'schedule' }}
         uses: slackapi/slack-github-action@v3.0.1
         with:
           method: chat.postMessage


### PR DESCRIPTION
Upgrade github actions due to Node.js 20 deprecation warning.

```
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as 
expected: actions/checkout@v4, slackapi/slack-github-action@v2.0.0. Actions will be forced to run with Node.js 
24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. 
Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 
now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your 
workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting 
ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: 
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```